### PR TITLE
增加Google.Protobuf序列化支持

### DIFF
--- a/Shared/Codecs/Serializer/ProtobufSerializer.cs
+++ b/Shared/Codecs/Serializer/ProtobufSerializer.cs
@@ -16,8 +16,8 @@ namespace rpcx.net.Shared.Codecs.Serializer {
         public object Deserialize(Type type, ReadOnlyMemory<byte> bytes) {
             if (type.IsAssignableFrom(typeof(IMessage))) {
                 var msg = (IMessage)Activator.CreateInstance(type);
-
-                using (var ms = new MemoryStream())
+                
+                using (var ms = new MemoryStream(bytes.ToArray()))
                 using (var input = new CodedInputStream(ms)) {
                     msg.MergeFrom(input);
                 }
@@ -29,11 +29,7 @@ namespace rpcx.net.Shared.Codecs.Serializer {
 
         public byte[] Serialize(object value) {
             if (value is IMessage msg) {
-                using (var ms = new MemoryStream())
-                using (var output = new CodedOutputStream(ms)) {
-                    msg.WriteTo(output);
-                    return ms.ToArray();
-                }
+                return msg.ToByteArray();
             }
             throw new NotImplementedException();
         }

--- a/Shared/Codecs/Serializer/ProtobufSerializer.cs
+++ b/Shared/Codecs/Serializer/ProtobufSerializer.cs
@@ -1,6 +1,5 @@
 ﻿using Google.Protobuf;
 using System;
-using System.IO;
 
 namespace rpcx.net.Shared.Codecs.Serializer {
     public class ProtobufSerializer : ISerializer {
@@ -16,11 +15,7 @@ namespace rpcx.net.Shared.Codecs.Serializer {
         public object Deserialize(Type type, ReadOnlyMemory<byte> bytes) {
             if (type.IsAssignableFrom(typeof(IMessage))) {
                 var msg = (IMessage)Activator.CreateInstance(type);
-                
-                using (var ms = new MemoryStream(bytes.ToArray()))
-                using (var input = new CodedInputStream(ms)) {
-                    msg.MergeFrom(input);
-                }
+                msg.MergeFrom(bytes.ToArray());
 
                 return msg;
             }

--- a/Shared/Codecs/Serializer/ProtobufSerializer.cs
+++ b/Shared/Codecs/Serializer/ProtobufSerializer.cs
@@ -1,27 +1,40 @@
-﻿using System;
+﻿using Google.Protobuf;
+using System;
+using System.IO;
 
-namespace rpcx.net.Shared.Codecs.Serializer
-{
-    public class ProtobufSerializer : ISerializer
-    {
+namespace rpcx.net.Shared.Codecs.Serializer {
+    public class ProtobufSerializer : ISerializer {
         private static ProtobufSerializer _default;
-        public static ProtobufSerializer Default
-        {
-            get
-            {
+        public static ProtobufSerializer Default {
+            get {
                 if (_default is null)
                     _default = new ProtobufSerializer();
                 return _default;
             }
         }
 
-        public object Deserialize(Type type, ReadOnlyMemory<byte> bytes)
-        {
+        public object Deserialize(Type type, ReadOnlyMemory<byte> bytes) {
+            if (type.IsAssignableFrom(typeof(IMessage))) {
+                var msg = (IMessage)Activator.CreateInstance(type);
+
+                using (var ms = new MemoryStream())
+                using (var input = new CodedInputStream(ms)) {
+                    msg.MergeFrom(input);
+                }
+
+                return msg;
+            }
             throw new NotImplementedException();
         }
 
-        public byte[] Serialize(object value)
-        {
+        public byte[] Serialize(object value) {
+            if (value is IMessage msg) {
+                using (var ms = new MemoryStream())
+                using (var output = new CodedOutputStream(ms)) {
+                    msg.WriteTo(output);
+                    return ms.ToArray();
+                }
+            }
             throw new NotImplementedException();
         }
     }

--- a/Shared/rpcx.net.Shared.csproj
+++ b/Shared/rpcx.net.Shared.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetty.Handlers" Version="0.7.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.18.1" />
     <PackageReference Include="MessagePack" Version="2.3.75" />
     <PackageReference Include="protobuf-net" Version="3.0.101" />
     <PackageReference Include="Snappy.Standard" Version="0.2.0" />


### PR DESCRIPTION
增加Google.Protobuf序列化支持。

1、编写proto文件。
2、通过protoc插件grpc_csharp_plugin生成csharp代码。格式为：
 ```text
protoc file.proto --csharp_out=. --grpc_out=. --plugin protoc-gen-grpc=%GOPATH%/bin/grpc_csharp_plugin.exe
```
3、proto文件生成的csharp实体类就是protobuf需要的文件，如下：
```cs
// ......
public sealed partial class SearchResponse : pb::IMessage<SearchResponse>
  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
      , pb::IBufferMessage
  #endif
  {
     //......
  }
// ......
```