### PR TITLE
增加Google.Protobuf序列化支持，增加tls支持

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -1,26 +1,34 @@
-﻿using DotNetty.Transport.Bootstrapping;
+﻿using DotNetty.Handlers.Tls;
+using DotNetty.Transport.Bootstrapping;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Sockets;
 using rpcx.net.Client.Generator;
 using rpcx.net.Shared.Codecs;
 using rpcx.net.Shared.Protocol;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using static rpcx.net.Shared.Utils;
 
-namespace rpcx.net.Client
-{
-    public class Option
-    {
+namespace rpcx.net.Client {
+    public class Option {
         public string Group { get; set; }
         public int Retries { get; set; }
         public Header.eType Types { get; set; }
 
-        public static Option Default
-        {
+        // 如果TLS双向认证，需要给定客户端证书, 该参数优先级比TargetHost要高
+        public X509Certificate2 ClienetCert { get; set; }
+
+        // 如果TLS单向认证，需要给定目标主机名称，对应服务器证书的CN（Common Name）
+        public string TargetHost { get; set; } = null;
+
+        public static Option Default {
             get => new Option() {
                 Retries = 3,
                 Types = Header.eType.MessagePack
@@ -28,13 +36,10 @@ namespace rpcx.net.Client
         }
     }
 
-    public class Client : SimpleChannelInboundHandler<Message>, IRPCClient
-    {
+    public class Client : SimpleChannelInboundHandler<Message>, IRPCClient {
         protected static IEventLoopGroup group;
-        protected static IEventLoopGroup Group
-        {
-            get
-            {
+        protected static IEventLoopGroup Group {
+            get {
                 if (group is null)
                     group = new MultithreadEventLoopGroup();
                 return group;
@@ -50,8 +55,7 @@ namespace rpcx.net.Client
         public delegate void ServerMessageHandler(object sender, Message msg);
         public event ServerMessageHandler OnServerMessage;
 
-        public Client(Option option = null)
-        {
+        public Client(Option option = null) {
             _option = option ?? Option.Default;
             _pending = new ConcurrentDictionary<long, TaskCompletionSource>();
         }
@@ -62,27 +66,36 @@ namespace rpcx.net.Client
         public bool IsClosing() => !(_chan?.Active).GetValueOrDefault(true);
         public bool IsShutdown() => _chan is null;
 
-        public bool Connect(string network, string address)
-        {
+        public bool Connect(string network, string address) {
             var bootstrap = new Bootstrap();
+
             bootstrap.Group(Group)
                 .Channel<TcpSocketChannel>()
                 .Option(ChannelOption.TcpNodelay, true)
-                .Handler(new ActionChannelInitializer<ISocketChannel>(chan =>
-                {
+                .Handler(new ActionChannelInitializer<ISocketChannel>(chan => {
                     var pipe = chan.Pipeline;
+                    if (_option.ClienetCert != null) {
+                        // 如果服务器证书与客户端证书的DnsName不一样，这里需要使用服务器的
+                        string targetHost = _option.ClienetCert.GetNameInfo(X509NameType.DnsName, false);
+                        List<X509Certificate> certList = new() { _option.ClienetCert };
+
+                        pipe.AddLast(new TlsHandler(stream => new SslStream(stream, true, (sender, certificate, chain, errors) => true), new ClientTlsSettings(targetHost, certList)));
+                    } else if (_option.TargetHost != null) {
+                        pipe.AddLast(new TlsHandler(stream => new SslStream(stream, true, (sender, certificate, chain, errors) => true), new ClientTlsSettings(_option.TargetHost)));
+                    }
+
                     pipe.AddLast(
                         new RpcxClientCodec(),
                         this
                     );
                 }));
+
             var addr = address.Split(new char[] { ':' });
             _chan = bootstrap.ConnectAsync(IPAddress.Parse(addr[0]), int.Parse(addr[1])).Result;
             return true;
         }
 
-        public async Task<TReply> Go<TArgs, TReply>(string servicePath, string serviceMethod, TArgs args, CancellationToken cancellationToken = default)
-        {
+        public async Task<TReply> Go<TArgs, TReply>(string servicePath, string serviceMethod, TArgs args, CancellationToken cancellationToken = default) {
             var header = Header.NewRequest(_option.Types);
             var msg = new Message(header) {
                 ServicePath = servicePath,
@@ -98,8 +111,7 @@ namespace rpcx.net.Client
             return (TReply)await tcs.Task.ConfigureAwait(false);
         }
 
-        public Task SendRaw(Message message, CancellationToken cancellationToken = default)
-        {
+        public Task SendRaw(Message message, CancellationToken cancellationToken = default) {
             message.Header.Seq = IdGen.Next();
             var tcs = new TaskCompletionSource();
             _pending.TryAdd(message.Header.Seq, tcs);
@@ -107,33 +119,25 @@ namespace rpcx.net.Client
             return tcs.Task;
         }
 
-        public void Close()
-        {
+        public void Close() {
             var chan = Interlocked.Exchange(ref _chan, null);
             chan.CloseAsync();
         }
         #endregion
 
         #region SimpleChannelInboundHandler<Message>
-        protected override void ChannelRead0(IChannelHandlerContext ctx, Message msg)
-        {
-            if(msg.Header.MessageStatusType == Header.eType.Error)
-            {
+        protected override void ChannelRead0(IChannelHandlerContext ctx, Message msg) {
+            if (msg.Header.MessageStatusType == Header.eType.Error) {
             }
-            if(msg.Header.MessageType == Header.eType.Request && !msg.Header.IsHeartbeat && msg.Header.IsOneWay)
-            {
+            if (msg.Header.MessageType == Header.eType.Request && !msg.Header.IsHeartbeat && msg.Header.IsOneWay) {
                 //ServerMessage
                 OnServerMessage?.Invoke(this, msg);
 
-            } else if (_pending.TryRemove(msg.Header.Seq, out var tcs))
-            {
+            } else if (_pending.TryRemove(msg.Header.Seq, out var tcs)) {
                 //ResponseMessage
-                if (tcs.ResultType is null)
-                {
+                if (tcs.ResultType is null) {
                     tcs.TrySetResult(msg.Payload);
-                }
-                else
-                {
+                } else {
                     var obj = GetSerializer(msg.Header.SerializeType).Deserialize(tcs.ResultType, msg.Payload);
                     if (obj is WithMetadata o)
                         o._metadata = msg.Metadata;

--- a/Client/rpcx.net.Client.csproj
+++ b/Client/rpcx.net.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.0.1</Version>
     <Authors>deeyi</Authors>

--- a/Shared/Codecs/Serializer/ProtobufSerializer.cs
+++ b/Shared/Codecs/Serializer/ProtobufSerializer.cs
@@ -1,5 +1,7 @@
 ﻿using Google.Protobuf;
 using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace rpcx.net.Shared.Codecs.Serializer {
     public class ProtobufSerializer : ISerializer {
@@ -12,19 +14,43 @@ namespace rpcx.net.Shared.Codecs.Serializer {
             }
         }
 
+        private static Dictionary<Type, bool> _cacheType = new Dictionary<Type, bool>();
+        private bool IsProtoContract(Type type) {
+            lock (_cacheType) {
+                if (_cacheType.ContainsKey(type)) {
+                    return _cacheType[type];
+                }
+                var attrs = type.GetCustomAttributes(typeof(ProtoBuf.ProtoContractAttribute), false);
+                bool exists = attrs.Length > 0;
+                _cacheType[type] = exists;
+                return exists;
+            }
+        }
+
         public object Deserialize(Type type, ReadOnlyMemory<byte> bytes) {
             if (type.IsAssignableFrom(typeof(IMessage))) {
+                // google.protobuf
                 var msg = (IMessage)Activator.CreateInstance(type);
                 msg.MergeFrom(bytes.ToArray());
 
                 return msg;
+            } else if (IsProtoContract(type)) {
+                // protobuf-net
+                return ProtoBuf.Serializer.NonGeneric.Deserialize(type, bytes);
             }
             throw new NotImplementedException();
         }
 
         public byte[] Serialize(object value) {
             if (value is IMessage msg) {
+                // google.protobuf
                 return msg.ToByteArray();
+            } else if (IsProtoContract(value.GetType())) {
+                // protobuf-net
+                using (var ms = new MemoryStream()) {
+                    ProtoBuf.Serializer.NonGeneric.Serialize(ms, value);
+                    return ms.ToArray();
+                }
             }
             throw new NotImplementedException();
         }

--- a/Shared/Codecs/Serializer/ProtobufSerializer.cs
+++ b/Shared/Codecs/Serializer/ProtobufSerializer.cs
@@ -16,8 +16,8 @@ namespace rpcx.net.Shared.Codecs.Serializer {
         public object Deserialize(Type type, ReadOnlyMemory<byte> bytes) {
             if (type.IsAssignableFrom(typeof(IMessage))) {
                 var msg = (IMessage)Activator.CreateInstance(type);
-
-                using (var ms = new MemoryStream())
+                
+                using (var ms = new MemoryStream(bytes.ToArray()))
                 using (var input = new CodedInputStream(ms)) {
                     msg.MergeFrom(input);
                 }
@@ -29,11 +29,7 @@ namespace rpcx.net.Shared.Codecs.Serializer {
 
         public byte[] Serialize(object value) {
             if (value is IMessage msg) {
-                using (var ms = new MemoryStream())
-                using (var output = new CodedOutputStream(ms)) {
-                    msg.WriteTo(output);
-                    return ms.ToArray();
-                }
+                return msg.ToByteArray();
             }
             throw new NotImplementedException();
         }

--- a/Shared/Codecs/Serializer/ProtobufSerializer.cs
+++ b/Shared/Codecs/Serializer/ProtobufSerializer.cs
@@ -1,6 +1,5 @@
 ﻿using Google.Protobuf;
 using System;
-using System.IO;
 
 namespace rpcx.net.Shared.Codecs.Serializer {
     public class ProtobufSerializer : ISerializer {
@@ -16,11 +15,7 @@ namespace rpcx.net.Shared.Codecs.Serializer {
         public object Deserialize(Type type, ReadOnlyMemory<byte> bytes) {
             if (type.IsAssignableFrom(typeof(IMessage))) {
                 var msg = (IMessage)Activator.CreateInstance(type);
-                
-                using (var ms = new MemoryStream(bytes.ToArray()))
-                using (var input = new CodedInputStream(ms)) {
-                    msg.MergeFrom(input);
-                }
+                msg.MergeFrom(bytes.ToArray());
 
                 return msg;
             }

--- a/Shared/Codecs/Serializer/ProtobufSerializer.cs
+++ b/Shared/Codecs/Serializer/ProtobufSerializer.cs
@@ -1,27 +1,40 @@
-﻿using System;
+﻿using Google.Protobuf;
+using System;
+using System.IO;
 
-namespace rpcx.net.Shared.Codecs.Serializer
-{
-    public class ProtobufSerializer : ISerializer
-    {
+namespace rpcx.net.Shared.Codecs.Serializer {
+    public class ProtobufSerializer : ISerializer {
         private static ProtobufSerializer _default;
-        public static ProtobufSerializer Default
-        {
-            get
-            {
+        public static ProtobufSerializer Default {
+            get {
                 if (_default is null)
                     _default = new ProtobufSerializer();
                 return _default;
             }
         }
 
-        public object Deserialize(Type type, ReadOnlyMemory<byte> bytes)
-        {
+        public object Deserialize(Type type, ReadOnlyMemory<byte> bytes) {
+            if (type.IsAssignableFrom(typeof(IMessage))) {
+                var msg = (IMessage)Activator.CreateInstance(type);
+
+                using (var ms = new MemoryStream())
+                using (var input = new CodedInputStream(ms)) {
+                    msg.MergeFrom(input);
+                }
+
+                return msg;
+            }
             throw new NotImplementedException();
         }
 
-        public byte[] Serialize(object value)
-        {
+        public byte[] Serialize(object value) {
+            if (value is IMessage msg) {
+                using (var ms = new MemoryStream())
+                using (var output = new CodedOutputStream(ms)) {
+                    msg.WriteTo(output);
+                    return ms.ToArray();
+                }
+            }
             throw new NotImplementedException();
         }
     }

--- a/Shared/rpcx.net.Shared.csproj
+++ b/Shared/rpcx.net.Shared.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetty.Handlers" Version="0.7.0" />
     <PackageReference Include="Google.Protobuf" Version="3.18.1" />
-    <PackageReference Include="MessagePack" Version="2.3.75" />
+    <PackageReference Include="MessagePack" Version="2.3.85" />
     <PackageReference Include="protobuf-net" Version="3.0.101" />
     <PackageReference Include="Snappy.Standard" Version="0.2.0" />
   </ItemGroup>

--- a/Shared/rpcx.net.Shared.csproj
+++ b/Shared/rpcx.net.Shared.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetty.Handlers" Version="0.7.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.18.1" />
     <PackageReference Include="MessagePack" Version="2.3.75" />
     <PackageReference Include="protobuf-net" Version="3.0.101" />
     <PackageReference Include="Snappy.Standard" Version="0.2.0" />

--- a/examples/Program.cs
+++ b/examples/Program.cs
@@ -1,28 +1,34 @@
 ﻿using rpcx.net.Client;
-using rpcx.net.Client.ServiceDiscovery;
 using System;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
 
-namespace examples
-{
-    public class Args
-    {
+namespace examples {
+    public class Args {
         public long A { get; set; }
         public long B { get; set; }
     }
 
-    public class Reply
-    {
+    public class Reply {
         public long C { get; set; }
     }
 
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var c = new Client(new Option()
-            {
+    class Program {
+        static void Main(string[] args) {
+            // NOTE: 必须将证书通过如下命令合并后才能使用。
+            // https://blog.csdn.net/yiquan_yang/article/details/113251552
+            // openssl pkcs12 -export -in client.pem -inkey client.key -out client.pfx
+
+            // 双向证书
+            var pfx = Path.Combine("conf", "normal", "client.pfx");
+            using var clientCert = new X509Certificate2(pfx);
+
+            var c = new Client(new Option() {
+                ClienetCert = clientCert, // 客户端证书
+                TargetHost = "01-matrix", // 如果同时客户端证书, 则该参数无效
                 Types = rpcx.net.Shared.Protocol.Header.eType.MessagePack, // | rpcx.net.Shared.Protocol.Header.eType.Gzip,
             });
+
             c.Connect("tcp", "127.0.0.1:8972");
             c.OnServerMessage += C_OnServerMessage;
 
@@ -39,8 +45,7 @@ namespace examples
             Console.ReadLine();
         }
 
-        private static void C_OnServerMessage(object sender, rpcx.net.Shared.Protocol.Message msg)
-        {
+        private static void C_OnServerMessage(object sender, rpcx.net.Shared.Protocol.Message msg) {
             throw new NotImplementedException();
         }
     }

--- a/examples/examples.csproj
+++ b/examples/examples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,6 +7,24 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Client\rpcx.net.Client.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="conf\normal\ca.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="conf\normal\client.csr">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="conf\normal\client.key">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="conf\normal\client.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="conf\normal\client.pfx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
增加Google.Protobuf序列化支持。

1、编写proto文件。
2、通过protoc插件grpc_csharp_plugin生成csharp代码。格式为：

protoc file.proto --csharp_out=. --grpc_out=. --plugin protoc-gen-grpc=%GOPATH%/bin/grpc_csharp_plugin.exe
3、proto文件生成的csharp实体类就是protobuf需要的文件，如下：

// ......
public sealed partial class SearchResponse : pb::IMessage<SearchResponse>
  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
      , pb::IBufferMessage
  #endif
  {
     //......
  }
// ......

4、增加Tls支持